### PR TITLE
Fix UDP max size issues

### DIFF
--- a/lib/opencensus/jaeger/version.rb
+++ b/lib/opencensus/jaeger/version.rb
@@ -1,5 +1,5 @@
 module OpenCensus
   module Jaeger
-    VERSION = '0.1.9'.freeze
+    VERSION = '0.1.10'.freeze
   end
 end

--- a/lib/opencensus/trace/exporters/jaeger_driver/udp_sender/udp_transport.rb
+++ b/lib/opencensus/trace/exporters/jaeger_driver/udp_sender/udp_transport.rb
@@ -65,7 +65,6 @@ module OpenCensus
                 if self.class.can_adjust_udp_max?
                   self.class.adjust_udp_max_size!
                   @logger.warn "Adjust UDP batch size: #{self.class.udp_max_size}"
-                  retrying = true
                   retry
                 else
                   @logger.error 'Unable to send span due to UDP max size. Give up!'

--- a/lib/opencensus/trace/exporters/jaeger_driver/udp_sender/udp_transport.rb
+++ b/lib/opencensus/trace/exporters/jaeger_driver/udp_sender/udp_transport.rb
@@ -6,7 +6,7 @@ module OpenCensus
           class UdpTransport
             FLAGS = 0
             DEFAULT_UDP_SIZE = 65536 # 64kb
-            MIN_UDP_SIZE = 4096 # 8kb
+            MIN_UDP_SIZE = 512 # 512 bytes
 
             class << self
               def udp_max_size


### PR DESCRIPTION
![screen shot 2019-03-07 at 00 46 36](https://user-images.githubusercontent.com/11613517/53907906-bf3dca00-4080-11e9-82f1-37d97c576e8d.png)

The tracing system is using UDP to transport the spans and traces from the app to the Jaeger client.  Whenever the transportation layer wants to send the data, it fetches the data is stored in a in-memory buffer, managed by Thrift. The amount of data is not predictable. Therefore, in many cases, it exceeds the UDP diagram size, which unfortunately depends on the OS, and even the user can config this number. On mac, the default value is 9216 (~9kb)

![screen shot 2019-03-07 at 02 32 24](https://user-images.githubusercontent.com/11613517/53908138-4e4ae200-4081-11e9-8197-87892d838f57.png)

This PR is to implement a smart retrying mechanism. 
- First, the process sets the batch size of 64kb. 
- If the data from the buffer exceeds the batch size, the data is split into chunks to send sequentially
- If the chunk gets `Errno::EMSGSIZE` exception, indicating the chunk is still bigger than the max allowing size, the process adjusts the max UDP, and retry.

This implementation is smart because:
- If the whole data is small enough, it won't be split, which maintain the current performance
- The max udp size is stored and managed per process. So, the size adjust happens only once, when the first big package arrives. It removes the retrying fees in later packages
- The size is adjustive to the current OS configuration. Even if the OS changes the setting after the process already starts, it can work well with new configuration.

Result:
![screen shot 2019-03-07 at 02 26 23](https://user-images.githubusercontent.com/11613517/53908758-a6ceaf00-4082-11e9-996e-3d77a007361f.png)
