### PR TITLE
invalid parent span IDs error.

### DIFF
--- a/lib/opencensus/trace/exporters/jaeger_driver.rb
+++ b/lib/opencensus/trace/exporters/jaeger_driver.rb
@@ -27,11 +27,12 @@ module OpenCensus
           tags = build_thrift_tags(span.attributes)
           logs = build_logs(span.time_events)
           references = build_references(span.links)
+          trace_id = span.trace_id
           trace_id_high = base16_hex_to_int64(
-            span.trace_id.slice(0, 16)
+            trace_id.slice(0, 16)
           )
           trace_id_low = base16_hex_to_int64(
-            span.trace_id.slice(16)
+            trace_id.slice(16, trace_id.size)
           )
           span_id = base16_hex_to_int64(
             span.span_id


### PR DESCRIPTION
Missing data for trace id.

OpenCensus TraceID =   8e8c06f2e1d321740bd7bfe4c677194b
JaegerDriver TraceID = 8e8c06f2e1d321740000000000000000

``` json:Jaeger Trace Json
{
    "data": [
        {
            "traceID": "8e8c06f2e1d321740000000000000000",
            "spans": [
                {
                    "traceID": "8e8c06f2e1d321740000000000000000",
                    
```

The cause is the slice of trace id low.

```
trace_id_low = base16_hex_to_int64(
  span.trace_id.slice(16)
)
```
